### PR TITLE
rename go module rhino-cli to openrhino.org/rhino-cli

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module rhino-cli
+module openrhino.org/rhino-cli
 
 go 1.19
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"rhino-cli/cmd"
+	"openrhino.org/rhino-cli/cmd"
 )
 
 func main() {


### PR DESCRIPTION
OpenRHINO中各项目保持一致