### PR TITLE
Read-current-ns-from-kubeconfig

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "rhino list",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/main.go",
+            "args": ["list", "-n", "default"]
+        },
+        {
+            "name": "rhino run",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/main.go",
+            "args": ["run", "openrhino/sample",
+                "--namespace",
+                "default"]
+        }
+    ]
+}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -12,8 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var name string
-var namespaced string
+var rhinojobName string
 
 var deleteCmd = &cobra.Command{
 	Use:   "delete [name]",
@@ -23,7 +22,7 @@ var deleteCmd = &cobra.Command{
 		if len(args) == 0 {
 			return fmt.Errorf("[name] cannot be empty")
 		}
-		name = args[0]
+		rhinojobName = args[0]
 		var configPath string
 		if len(kubeconfig) == 0 {
 			if home := homedir.HomeDir(); home != "" {
@@ -34,29 +33,29 @@ var deleteCmd = &cobra.Command{
 			}
 		} else {
 			configPath = kubeconfig
-		}		
+		}
 		config, err := clientcmd.BuildConfigFromFlags("", configPath)
 		if err != nil {
 			return err
 		}
-	
+
 		dynamicClient, err := dynamic.NewForConfig(config)
 		if err != nil {
 			return err
 		}
-	
-		err = dynamicClient.Resource(RhinoJobGVR).Namespace(namespaced).Delete(context.TODO(), name, metav1.DeleteOptions{})
+
+		err = dynamicClient.Resource(RhinoJobGVR).Namespace(namespace).Delete(context.TODO(), rhinojobName, metav1.DeleteOptions{})
 		if err != nil {
 			fmt.Println("Error:", err.Error())
 			os.Exit(0)
 		}
-		fmt.Println("RhinoJob " + name + " deleted")
-		return nil	
+		fmt.Println("RhinoJob " + rhinojobName + " deleted")
+		return nil
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(deleteCmd)
-	deleteCmd.Flags().StringVarP(&namespaced, "namespace", "n", "default", "namespace of the rhinojob")
+	deleteCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "namespace of the rhinojob")
 	deleteCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "kubernetes config path")
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"context"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
 	"path/filepath"
 	"github.com/spf13/cobra"
@@ -34,14 +32,13 @@ var deleteCmd = &cobra.Command{
 		} else {
 			configPath = kubeconfig
 		}
-		config, err := clientcmd.BuildConfigFromFlags("", configPath)
+
+		dynamicClient, currentNamespace, err := buildFromKubeconfig(configPath)
 		if err != nil {
 			return err
 		}
-
-		dynamicClient, err := dynamic.NewForConfig(config)
-		if err != nil {
-			return err
+		if namespace == "" {
+			namespace = *currentNamespace
 		}
 
 		err = dynamicClient.Resource(RhinoJobGVR).Namespace(namespace).Delete(context.TODO(), rhinojobName, metav1.DeleteOptions{})
@@ -56,6 +53,6 @@ var deleteCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(deleteCmd)
-	deleteCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "namespace of the rhinojob")
+	deleteCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace of the rhinojob")
 	deleteCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "kubernetes config path")
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -14,9 +14,6 @@ import (
 	rhinojob "github.com/OpenRHINO/RHINO-Operator/api/v1alpha1"
 )
 
-var namespace string
-var kubeconfig string
-
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all rhino jobs",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,8 @@ var rootCmd = &cobra.Command{
 	Use:   "rhino",
 	Short: "\nRHINO-CLI - Manage your OpenRHINO functions and jobs",
 }
+var namespace string
+var kubeconfig string
 
 func Execute() {
 	err := rootCmd.Execute()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,5 @@ func Execute() {
 	}
 }
 
-func init() {
-}
 
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
-	"os"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+	"os"
 )
 
 var RhinoJobGVR = schema.GroupVersionResource{Group: "openrhino.org", Version: "v1alpha1", Resource: "rhinojobs"}
@@ -21,5 +23,31 @@ func Execute() {
 	}
 }
 
+func buildFromKubeconfig(configPath string) (dynamicClient *dynamic.DynamicClient, currentNamespace *string, err error) {
+	// We use 2 kinds of config here.
+	// The dynamicClient need to be constructed with rest.Config.
+	// On the other hand, we need to use api.Config or ClientConfig to
+	// read the context info and current namespace from the kubeconfig file.
+	// The rest.Config does not include the namespace.
+	config, err := clientcmd.BuildConfigFromFlags("", configPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	dynamicClient, err = dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, nil, err
+	}
 
+	cmdapiConfig, err := clientcmd.LoadFromFile(configPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	context, exist := cmdapiConfig.Contexts[cmdapiConfig.CurrentContext]
+	if exist {
+		currentNamespace = &context.Namespace
+	} else {
+		return nil, nil, err
+	}
 
+	return dynamicClient, currentNamespace, nil
+}


### PR DESCRIPTION
Use the current namespace in the kubeconfig file when the -n arg is not set for `list`, `run` and `delete`.