### PR TITLE
Fix #44. Improve error handling of ldd.sh

### DIFF
--- a/samples/integration/ldd.sh
+++ b/samples/integration/ldd.sh
@@ -1,40 +1,51 @@
 #!/bin/sh
-# set -o errexit
-# set +o nounset
-# set -o pipefail
+set -o errexit
+set -o nounset
+set -o pipefail
 
-file_path=$(find ./ -name $FUNC_NAME)
+# If there are multiple files found, only use the first result
+file_path=$(find ./ -name "$FUNC_NAME" | head -n 1)
 if [ "$file_path" ]; then
-    mv $file_path /app/$FUNC_NAME
-    echo "loding app $FUNC_NAME"
+    mv "$file_path" "/app/$FUNC_NAME"
+    echo "loading app $FUNC_NAME"
 else
-    echo "cannot find file $FUNC_NAME!"
+# Exit and report an err when no $FUNC_NAME file is found
+    echo "cannot find file $FUNC_NAME!" >&2
     exit 1
 fi
 
 if [ ! -d "/shared_lib" ]; then
-    mkdir /shared_lib
+    mkdir "/shared_lib"
 fi
-cd /shared_lib
-echo "dir created"
+cd "/shared_lib"
+echo "The shared_lib dir created"
 
-ldd /app/$FUNC_NAME | grep -vE "ld-musl-x86_64|mpi" | awk '{print $3}' > path.txt
-echo "shared lib found"
+# Identify which libs need to loaded
+sharedlibs=$(ldd "/app/$FUNC_NAME" | grep -vE "ld-musl-x86_64|mpi" | awk '{print $3}' || true)
+if [ "$sharedlibs" != "" ]; then
+    echo "shared libs found"
+    echo "$sharedlibs" > path.txt
+else
+    echo "no shared lib need to be loaded"
+    exit 0
+fi
 
+# Seek for the share libs
 while read -r line
-do  
-    islink=$(ls -l $line | grep -e " -> ")
-    if [[ "$islink" != "" ]]
+do
+    if [ "$line" = "" ]; then continue; fi
+    islink=$(ls -l "$line" | grep ' -> ' || true)
+    if [ "$islink" != "" ]
     then
-        dir=$(dirname $line)
-        base=$(basename $line)
-        file=$(ls -l $line | awk '{print $NF}')
-        cp ${dir}"/"${file} /shared_lib/$base
-        echo cp ${dir}"/"${file} /shared_lib/$base
+        dir=$(dirname "$line")
+        base=$(basename "$line")
+        file=$(ls -l "$line" | awk '{print $NF}')
+        cp -p "${dir}/${file}" "/shared_lib/$base"
+        echo "cp ${dir}/${file} /shared_lib/$base"
     else
-        cp $line /shared_lib/
-        echo cp $line /shared_lib/
+        cp -p "$line" "/shared_lib/"
+        echo "cp $line /shared_lib/"
     fi
 done < path.txt
 rm path.txt
-echo "ldd analysis success!"      
+echo "ldd analysis success!"

--- a/samples/integration/ldd.sh
+++ b/samples/integration/ldd.sh
@@ -4,7 +4,7 @@ set -o nounset
 set -o pipefail
 
 # Look for executable files named $FUNC_NAME and check uniqueness
-file_path=$(find ./ -type f -name $FUNC_NAME -executable)
+file_path=$(find ./ -type f -name "$FUNC_NAME" -executable)
 if [ "$file_path" ]; then
     if [ "$(echo "$file_path" | wc -l)" -gt 1 ]; then
         echo "Found multiple executable files named '$FUNC_NAME'. Please check your Makefile!" >&2

--- a/templates/func/ldd.sh
+++ b/templates/func/ldd.sh
@@ -1,40 +1,51 @@
 #!/bin/sh
-# set -o errexit
-# set +o nounset
-# set -o pipefail
+set -o errexit
+set -o nounset
+set -o pipefail
 
-file_path=$(find ./ -name $FUNC_NAME)
+# If there are multiple files found, only use the first result
+file_path=$(find ./ -name "$FUNC_NAME" | head -n 1)
 if [ "$file_path" ]; then
-    mv $file_path /app/$FUNC_NAME
-    echo "loding app $FUNC_NAME"
+    mv "$file_path" "/app/$FUNC_NAME"
+    echo "loading app $FUNC_NAME"
 else
-    echo "cannot find file $FUNC_NAME!"
+# Exit and report an err when no $FUNC_NAME file is found
+    echo "cannot find file $FUNC_NAME!" >&2
     exit 1
 fi
 
 if [ ! -d "/shared_lib" ]; then
-    mkdir /shared_lib
+    mkdir "/shared_lib"
 fi
-cd /shared_lib
-echo "dir created"
+cd "/shared_lib"
+echo "The shared_lib dir created"
 
-ldd /app/$FUNC_NAME | grep -vE "ld-musl-x86_64|mpi" | awk '{print $3}' > path.txt
-echo "shared lib found"
+# Identify which libs need to loaded
+sharedlibs=$(ldd "/app/$FUNC_NAME" | grep -vE "ld-musl-x86_64|mpi" | awk '{print $3}' || true)
+if [ "$sharedlibs" != "" ]; then
+    echo "shared libs found"
+    echo "$sharedlibs" > path.txt
+else
+    echo "no shared lib need to be loaded"
+    exit 0
+fi
 
+# Seek for the share libs
 while read -r line
-do  
-    islink=$(ls -l $line | grep -e " -> ")
-    if [[ "$islink" != "" ]]
+do
+    if [ "$line" = "" ]; then continue; fi
+    islink=$(ls -l "$line" | grep ' -> ' || true)
+    if [ "$islink" != "" ]
     then
-        dir=$(dirname $line)
-        base=$(basename $line)
-        file=$(ls -l $line | awk '{print $NF}')
-        cp ${dir}"/"${file} /shared_lib/$base
-        echo cp ${dir}"/"${file} /shared_lib/$base
+        dir=$(dirname "$line")
+        base=$(basename "$line")
+        file=$(ls -l "$line" | awk '{print $NF}')
+        cp -p "${dir}/${file}" "/shared_lib/$base"
+        echo "cp ${dir}/${file} /shared_lib/$base"
     else
-        cp $line /shared_lib/
-        echo cp $line /shared_lib/
+        cp -p "$line" "/shared_lib/"
+        echo "cp $line /shared_lib/"
     fi
 done < path.txt
 rm path.txt
-echo "ldd analysis success!"      
+echo "ldd analysis success!"

--- a/templates/func/ldd.sh
+++ b/templates/func/ldd.sh
@@ -4,7 +4,7 @@ set -o nounset
 set -o pipefail
 
 # Look for executable files named $FUNC_NAME and check uniqueness
-file_path=$(find ./ -type f -name $FUNC_NAME -executable)
+file_path=$(find ./ -type f -name "$FUNC_NAME" -executable)
 if [ "$file_path" ]; then
     if [ "$(echo "$file_path" | wc -l)" -gt 1 ]; then
         echo "Found multiple executable files named '$FUNC_NAME'. Please check your Makefile!" >&2


### PR DESCRIPTION
1. Set `errexit`, `nounset` and `pipefail` to make sure the script stops and returns the exit status when an error occurs
2. If multiple `mpi-func` files are found, use the first result
3. Use `|| true` to avoid error reporting when get empty results when `| grep` or `| awk`
4. use "" with variables to ensure they are interpreted as single entities even if there are spaces or other special characters within the content of the variables
5. If there is no shared lib need to be loaded, exit 0 immediately to avoid causing errors in the subsequent process