### PR TITLE
fix #47, the empty namespace issue

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,10 @@ func buildFromKubeconfig(configPath string) (dynamicClient *dynamic.DynamicClien
 	}
 	context, exist := cmdapiConfig.Contexts[cmdapiConfig.CurrentContext]
 	if exist {
+		if context.Namespace == "" { 
+			//If namespace is not defined in kubeconfig, use "default"
+			context.Namespace = "default"
+		}
 		currentNamespace = &context.Namespace
 	} else {
 		return nil, nil, err


### PR DESCRIPTION
Sometimes the current context in the kube config file does not contain a namespace. In this case, use "default" namespace.