### PR TITLE
Add quotes around funcName in YAML

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -110,13 +110,13 @@ kind: RhinoJob
 metadata:
   labels:
     app.kubernetes.io/name: rhinojob 
-    app.kubernetes.io/instance: `
-	yamlFile += r.funcName + `
+    app.kubernetes.io/instance: "`
+	yamlFile += r.funcName + `"
     app.kubernetes.io/part-of: rhino-operator
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: rhino-operator
-  name: `
-	yamlFile += r.funcName + `
+  name: "`
+	yamlFile += r.funcName + `"
 spec:
   image: "`
 	yamlFile += args[0] + `"


### PR DESCRIPTION
Add quotes around funcName in YAML to ensure it is treated as a string
![image](https://user-images.githubusercontent.com/40471189/230812169-9e1fce08-4cf0-40e3-9e84-1b3e306ee70e.png)
