### PR TITLE
Fix #73

### DIFF
--- a/cmd/cmd_utils.go
+++ b/cmd/cmd_utils.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -31,9 +32,28 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
 )
 
 var RhinoJobGVR = schema.GroupVersionResource{Group: "openrhino.org", Version: "v1alpha1", Resource: "rhinojobs"}
+
+func getKubeconfigPath(kubeconfig string) (string, error) {
+	if kubeconfig == "" {
+		if home := homedir.HomeDir(); home != "" {
+			kubeconfig = filepath.Join(home, ".kube", "config")
+			// Check if the file exists.
+			if _, err := os.Stat(kubeconfig); os.IsNotExist(err) {
+				return "", fmt.Errorf("kubeconfig file not found in home directory")
+			} else if err != nil {
+				// Some other error occurred when checking if the file exists.
+				return "", fmt.Errorf("error checking kubeconfig file: %v", err)
+			}
+		} else { // home == ""
+			return "", fmt.Errorf("home directory not found")
+		}
+	}
+	return kubeconfig, nil
+}
 
 func buildFromKubeconfig(configPath string) (dynamicClient *dynamic.DynamicClient, currentNamespace *string, err error) {
 	// We use 2 kinds of config here.

--- a/cmd/cmd_utils.go
+++ b/cmd/cmd_utils.go
@@ -39,7 +39,9 @@ var RhinoJobGVR = schema.GroupVersionResource{Group: "openrhino.org", Version: "
 
 func getKubeconfigPath(kubeconfig string) (string, error) {
 	if kubeconfig == "" {
-		if home := homedir.HomeDir(); home != "" {
+		if home := homedir.HomeDir(); home == "" {
+			return "", fmt.Errorf("home directory not found")
+		} else {
 			kubeconfig = filepath.Join(home, ".kube", "config")
 			// Check if the file exists.
 			if _, err := os.Stat(kubeconfig); os.IsNotExist(err) {
@@ -48,8 +50,6 @@ func getKubeconfigPath(kubeconfig string) (string, error) {
 				// Some other error occurred when checking if the file exists.
 				return "", fmt.Errorf("error checking kubeconfig file: %v", err)
 			}
-		} else { // home == ""
-			return "", fmt.Errorf("home directory not found")
 		}
 	}
 	return kubeconfig, nil

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -18,11 +18,9 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/util/homedir"
 )
 
 type DeleteOptions struct {
@@ -51,12 +49,11 @@ func (d *DeleteOptions) argsCheck(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("[name] cannot be empty")
 	}
 	d.rhinojobName = args[0]
-	if len(d.kubeconfig) == 0 {
-		if home := homedir.HomeDir(); home != "" {
-			d.kubeconfig = filepath.Join(home, ".kube", "config")
-		} else {
-			return fmt.Errorf("kubeconfig file not found, please use --config to specify the absolute path")
-		}
+
+	var err error
+	d.kubeconfig, err = getKubeconfigPath(d.kubeconfig)
+	if err != nil {
+		return fmt.Errorf("%v, please set the kubeconfig path by --kubeconfig", err)
 	}
 
 	return nil

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -20,14 +20,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"text/tabwriter"
 
 	rhinojob "github.com/OpenRHINO/RHINO-Operator/api/v1alpha1"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/util/homedir"
 )
 
 type ListOptions struct {
@@ -60,12 +58,10 @@ func (l *ListOptions) list(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get the kubeconfig file
-	if len(l.kubeconfig) == 0 {
-		if home := homedir.HomeDir(); home != "" {
-			l.kubeconfig = filepath.Join(home, ".kube", "config")
-		} else {
-			return fmt.Errorf("kubeconfig file not found, please use --config to specify the absolute path")
-		}
+	var err error
+	l.kubeconfig, err = getKubeconfigPath(l.kubeconfig)
+	if err != nil {
+		return fmt.Errorf("%v, please set the kubeconfig path by --kubeconfig", err)
 	}
 
 	// Build the dynamic client

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"strconv"
 
 	rhinojob "github.com/OpenRHINO/RHINO-Operator/api/v1alpha1"
@@ -28,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/util/homedir"
 )
 
 type RunOptions struct {
@@ -78,12 +76,11 @@ func (r *RunOptions) run(cmd *cobra.Command, args []string) error {
 	if r.timeToLive < 0 {
 		return fmt.Errorf("the time to live (--ttl) must be greater than or equal to 0")
 	}
-	if r.kubeconfig == "" {
-		if home := homedir.HomeDir(); home != "" {
-			r.kubeconfig = filepath.Join(home, ".kube", "config")
-		} else {
-			return fmt.Errorf("kubeconfig file not found, please use --config to specify the absolute path")
-		}
+
+	var err error
+	r.kubeconfig, err = getKubeconfigPath(r.kubeconfig)
+	if err != nil {
+		return fmt.Errorf("%v, please set the kubeconfig path by --kubeconfig", err)
 	}
 
 	dynamicClient, currentNamespace, err := buildFromKubeconfig(r.kubeconfig)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,11 +18,8 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -104,20 +101,11 @@ func (v *VersionOptions) getRhinoServerVersion() (string, error) {
 
 // RunVersionCommand runs the version command
 func (v *VersionOptions) RunVersionCommand(cmd *cobra.Command, args []string) error {
-	if v.kubeconfig == "" {
-		homeDir, err := homedir.Dir()
-		if err != nil {
-			return fmt.Errorf("could not get home directory: %s,please use --kubeconfig to specify the absolute path", err)
-		}
-		kubeconfigPath := filepath.Join(homeDir, ".kube", "config")
-		_, err = os.Stat(kubeconfigPath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return fmt.Errorf("kubeconfig file not found at %s, please use --kubeconfig to specify the absolute path", kubeconfigPath)
-			}
-			return fmt.Errorf("error checking kubeconfig file at %s: %s", kubeconfigPath, err)
-		}
-		v.kubeconfig = kubeconfigPath
+	// Get the kubeconfig file
+	var err error
+	v.kubeconfig, err = getKubeconfigPath(v.kubeconfig)
+	if err != nil {
+		return fmt.Errorf("%v, please set the kubeconfig path by --kubeconfig", err)
 	}
 
 	// Print the version of Kubernetes


### PR DESCRIPTION
Correct the logic to check `~/.kube/config` file and  encapsulate the duplicated code in delete, list, run, and version commands with function getKubeconfigPath()