### PR TITLE
added creation time column to `rhino list` output

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -80,10 +80,10 @@ func (l *ListOptions) list(cmd *cobra.Command, args []string) error {
 		fmt.Println("Warning: no RhinoJobs found in the namespace")
 	} else {
 		w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
-		fmt.Fprintln(w, "Name\tParallelism\tStatus")
+		fmt.Fprintln(w, "Name\tParallelism\tStatus\tCreation Time")
 
 		for _, rj := range list.Items {
-			fmt.Fprintf(w, "%s\t%d\t%s\n", rj.Name, *rj.Spec.Parallelism, rj.Status.JobStatus)
+			fmt.Fprintf(w, "%s\t%d\t%s\t%v\n", rj.Name, *rj.Spec.Parallelism, rj.Status.JobStatus, rj.CreationTimestamp.Time)
 		}
 
 		// 刷新输出，确保所有内容写入 stdout


### PR DESCRIPTION
<img width="574" alt="image" src="https://github.com/OpenRHINO/RHINO-CLI/assets/20229719/50e4abb6-7ffb-4411-a494-1e052e9d9287">

Fix #80 

Note: 
This version of `rhino list` does display the "Age" in the same style as `kubectl get`, since the implementation would be much more complicated, and the output style of `kubectl get` does not closely resemble that of `slurm`. Therefore,  it is challenging to determine which style would be more suitable for our target users. I suggest we postpone this until the next version cycle and, for the version 0.2.0, display the `Creation Time` as a timestamp instead of `Age` following the `kubectl` style.